### PR TITLE
fix: RESTfulAPI仕様の400応答のレスポンスボディの定義を訂正

### DIFF
--- a/packages/restful/doc/openapi.yaml
+++ b/packages/restful/doc/openapi.yaml
@@ -110,10 +110,12 @@ components:
     BadRequestViolation:
       type: object
       properties:
-        propertyName:
+        property:
           type: string
+          description: 制約違反のあったプロパティ
         message:
           type: string
+          description: 制約違反の内容
       required:
-        - propertyName
+        - property
         - message


### PR DESCRIPTION
Close #31 