### PR TITLE
fix: RESTfulAPI仕様の200応答のレスポンスボディの定義を訂正

### DIFF
--- a/packages/restful/doc/openapi.yaml
+++ b/packages/restful/doc/openapi.yaml
@@ -53,7 +53,7 @@ components:
           items:
             $ref: '#/components/schemas/MinimumHourlyWageView'
       required:
-        - minimumHourlyWagesAndNextRevisions
+        - minimumHourlyWageViews
     MinimumHourlyWageView:
       type: object
       description: ある日付における最低賃金と改定予定


### PR DESCRIPTION
Close #33 