### PR TITLE
fix: OpenAPIのレスポンスボディ定義でprefectureCodeプロパティのexampleを文字列にする

### DIFF
--- a/packages/restful/doc/openapi.yaml
+++ b/packages/restful/doc/openapi.yaml
@@ -27,7 +27,6 @@ paths:
             items: 
               type: string
           description: JIS X0401 都道府県コード (2桁・ゼロ埋め)
-          example: '01' 
           required: false
       responses:
         '200':
@@ -65,7 +64,7 @@ components:
         prefectureCode:
           type: string
           description: JIS X0401 都道府県コード (2桁・ゼロ埋め)
-          example: 01
+          example: "01"
         next:
           type: object
           description: 改定予定

--- a/packages/restful/src/gen/schema.d.ts
+++ b/packages/restful/src/gen/schema.d.ts
@@ -37,7 +37,7 @@ export interface components {
             hourlyWage: number;
             /**
              * @description JIS X0401 都道府県コード (2桁・ゼロ埋め)
-             * @example 1
+             * @example 01
              */
             prefectureCode: string;
             /** @description 改定予定 */
@@ -92,10 +92,7 @@ export interface operations {
                  * @example 2024-09-30
                  */
                 date: string;
-                /**
-                 * @description JIS X0401 都道府県コード (2桁・ゼロ埋め)
-                 * @example 01
-                 */
+                /** @description JIS X0401 都道府県コード (2桁・ゼロ埋め) */
                 prefectureCodes?: string[];
             };
             header?: never;


### PR DESCRIPTION
Close #37 